### PR TITLE
fix for displaying logs correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # hubot simple logger
 
 hubot-simple-logger is message file logger and simple web interface
-- this is a fixed version which handles missing text in logs
+- this is a fixed version of anarchers repo, which handles missing text in logs
 - it also handles private messages on irc (msg hubot and get your reply in a private channel)
+- private messages are not saved to logs
 
 # Install & Use 
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # hubot simple logger
 
 hubot-simple-logger is message file logger and simple web interface
+this is a fixed version which handles missing text in logs
 
 # Install & Use 
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ hubot-simple-logger is message file logger and simple web interface
 
 # Install & Use 
 
-- If you want to use with docker, please consider this dockerfile https://github.com/nacyot/docker-hubot-simple-logger
+- Install anarcher's version of hubot-simple-logger and then overwrite YOUR_HUBOT_HOME/node_modules/hubot-simple-logger/src/scripts/hubot-simple-logger.coffee with the version from this repo
 
 
 ## Environment Variables

--- a/src/scripts/hubot-simple-logger.coffee
+++ b/src/scripts/hubot-simple-logger.coffee
@@ -69,7 +69,15 @@ render_log = (req,res,channel,file,date,dates,latest) ->
             event.timestamp = event.date.toString("%H:%M:%S:%L")
 
             if event.message?
-                event.message = escapeHtml  event.message
+                try
+                    event.message = escapeHtml  event.message
+                catch error
+                    # Do not process event.messages that aren't text strings,
+                    # just log them. Alternatively, one could call:
+                    # event.message = escapeHtml JSON.stringify(event.message)
+                    debugmsg = JSON.stringify event.message
+                    console.log "message is not text: #{debugmsg}"
+                    continue
                 event.message = event.message.replace(/\r\n|\r|\n/g, "<br/>")
                 event.message = convert.toHtml event.message
 

--- a/src/scripts/hubot-simple-logger.coffee
+++ b/src/scripts/hubot-simple-logger.coffee
@@ -131,7 +131,11 @@ module.exports = (robot) ->
         date = new Tempus()
         room = res.message.user.room || 'general'
         user = res.message.user.name || res.message.user.id || 'unknown'
-        log_message(logs_root,date,type,room,{ 'message' : res.message.text , 'user' : user })
+        if res.message.user.room?
+            log_message(logs_root,date,type,room,{ 'message' : res.message.text , 'user' : user })
+        else
+            robot.logger.debug "Private message: #{res.message.text} will not show in logs."
+            return
 
     # Add a listener that matches all messages and calls log_message with redis and robot instances and a Response object
     robot.listeners.push new Listener(robot, ((msg) -> return true), (res) -> _log_message(res))

--- a/src/scripts/hubot-simple-logger.coffee
+++ b/src/scripts/hubot-simple-logger.coffee
@@ -148,7 +148,9 @@ module.exports = (robot) ->
         reply: robot.Response.prototype.reply
 
     robot.Response.prototype.send = (strings...) ->
-        log_response @message.room, strings...
+
+        if not @message.room == null
+            log_response @message.room, strings...
         response_orig.send.call @,strings...
 
     robot.Response.prototype.reply = (strings...) ->


### PR DESCRIPTION
Hi,

I had to change the code that handles the processing of messages. When hubot logged a message that contained failed output from a shell command {"killed":false,"code":1,"signal":null} , the function escapeHtml started throwing exceptions, because event.message wasn't string, but object. No further messages were processed and webpage with logs for that particular day would not display.

I have added a failsafe. If escapeHtml fails, the message is silenty discarded and logged. 

Alternatively, it is possible to convert the message to a string and display that string instead. 

You can decide which one is better (log and discard, or display) and merge it appropriately.

Thanks.