### PR TITLE
Use HUBOT_LOGS_PORT for port number

### DIFF
--- a/src/scripts/hubot-simple-logger.coffee
+++ b/src/scripts/hubot-simple-logger.coffee
@@ -167,7 +167,7 @@ module.exports = (robot) ->
         response_orig.reply.call @,strings...
 
     #init app
-    port = process.env.LOGS_PORT || 8086
+    port = process.env.HUBOT_LOGS_PORT || process.env.LOGS_PORT || 8086
     robot.logger_app = express()
     robot.logger_app.configure( ->
         robot.logger_app.set 'views', __dirname + '/../views'


### PR DESCRIPTION
As specified in the documentation, the port to listen to should be
`HUBOT_LOGS_PORT` and not `LOGS_PORT`. Keep the latter for compatibility
with people already using `LOGS_PORT`.
